### PR TITLE
rulescript accessor

### DIFF
--- a/rulescript/IRuleScriptCustomAccessor.hx
+++ b/rulescript/IRuleScriptCustomAccessor.hx
@@ -1,0 +1,11 @@
+package rulescript;
+
+/**
+ * Provides custom property access for RuleScript.
+ * @param `_rget` is called when **getting** a property.
+ * @param `_rset` is called when **setting** a property.
+ */
+interface IRuleScriptCustomAccessor {
+	public function _rset(id:String, value:Dynamic):Dynamic;
+	public function _rget(id:String):Dynamic;
+}

--- a/rulescript/IRuleScriptCustomAccessor.hx
+++ b/rulescript/IRuleScriptCustomAccessor.hx
@@ -2,10 +2,10 @@ package rulescript;
 
 /**
  * Provides custom property access for RuleScript.
- * @param `_rget` is called when **getting** a property.
- * @param `_rset` is called when **setting** a property.
+ * @param `getField` is called when **getting** a property.
+ * @param `setField` is called when **setting** a property.
  */
 interface IRuleScriptCustomAccessor {
-	public function _rset(id:String, value:Dynamic):Dynamic;
-	public function _rget(id:String):Dynamic;
+	public function setField(id:String, value:Dynamic):Dynamic;
+	public function getField(id:String):Dynamic;
 }

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -537,7 +537,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		}
 
 		if(o is IRuleScriptCustomAccessor)
-			return cast(o, IRuleScriptCustomAccessor)._rget(f);
+			return cast(o, IRuleScriptCustomAccessor).getField(f);
 
 		if (o is RuleScriptedClass)
 		{
@@ -579,7 +579,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		}
 
 		if(o is IRuleScriptCustomAccessor)
-			return cast(o, IRuleScriptCustomAccessor)._rset(f, v);
+			return cast(o, IRuleScriptCustomAccessor).setField(f, v);
 		
 		if (o is RuleScriptedClass)
 		{

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -536,6 +536,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				o = superInstance;
 		}
 
+		if(o is IRuleScriptCustomAccessor)
+			return cast(o, IRuleScriptCustomAccessor)._rget(f);
+
 		if (o is RuleScriptedClass)
 		{
 			var cl:RuleScriptedClass = cast(o, RuleScriptedClass);
@@ -575,6 +578,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				o = superInstance;
 		}
 
+		if(o is IRuleScriptCustomAccessor)
+			return cast(o, IRuleScriptCustomAccessor)._rset(f, v);
+		
 		if (o is RuleScriptedClass)
 		{
 			var cl:RuleScriptedClass = cast(o, RuleScriptedClass);


### PR DESCRIPTION
> [!IMPORTANT]  
> This PR introduces the `IRuleScriptCustomAccessor` interface, which allows classes to define custom getters and setters for property access.
>
>When implemented, the interface's `getField` and `setField` methods will be used whenever a script gets or sets a property on an object with the interface `IRuleScriptCustomAccessor`.

Source:
```haxe
package test;

import rulescript.types.IRuleScriptCustomAccessor;

class CustomRulescriptBehaviorTest implements IRuleScriptCustomAccessor
{
	var data = {
		noob: "cool!",
		bruh: "YEAH!"
	}

        final duh : String = "testing123";

	public function new() : Void {}

	public function setField(i:String, v:Dynamic):Dynamic
	{
		Reflect.setProperty(data, i, v);
		return v;
	}

	public function getField(i:String):Dynamic
	{
		return Reflect.getProperty(data, i);
	}
}
```

test.rhx:
```haxe
import test.CustomRulescriptBehaviorTest;

var v1 = new CustomRulescriptBehaviorTest();
trace([v1.noob, v1.bruh, v1.duh]); // Returns: ["cool!", "YEAH!", null]
```
