### PR TITLE
public/static shared variables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /test/export
 hxformat.json
 /test/dump
+/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Shared variables between interps. (see [#28](https://github.com/Kriptel/RuleScript/pull/28))
 - Scripted typedef.
 - Neo interpreter.
 - Regular expressions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Shared variables between interps. (see [#28](https://github.com/Kriptel/RuleScript/pull/28))
+- Shared variables between interps. (see [#29](https://github.com/Kriptel/RuleScript/pull/29))
 - Scripted typedef.
 - Neo interpreter.
 - Regular expressions.

--- a/rulescript/Context.hx
+++ b/rulescript/Context.hx
@@ -12,8 +12,7 @@ import rulescript.types.ScriptedType;
  */
 class Context
 {
-	public var publicVariables:Map<String, Dynamic> = []; 
-	public var staticVariables:Map<String, Dynamic> = [];
+	public var sharedVariables:Map<String, Dynamic> = []; 
 	
 	public var types:Map<String, Dynamic> = [];
 

--- a/rulescript/Context.hx
+++ b/rulescript/Context.hx
@@ -12,11 +12,13 @@ import rulescript.types.ScriptedType;
  */
 class Context
 {
-	public var sharedVariables:Map<String, Dynamic> = []; 
+	public var publicVariables:Map<String, Dynamic> = []; 
+	public var staticVariables:Map<String, Dynamic> = []; 
 
 	public function resetVariables():Void
 	{
-		sharedVariables = [];// yuhuh -orbl
+		publicVariables = []; // yuhuh -orbl
+		staticVariables = [];
 	}
 	
 	public var types:Map<String, Dynamic> = [];

--- a/rulescript/Context.hx
+++ b/rulescript/Context.hx
@@ -12,6 +12,9 @@ import rulescript.types.ScriptedType;
  */
 class Context
 {
+	public var publicVariables:Map<String, Dynamic> = []; 
+	public var staticVariables:Map<String, Dynamic> = [];
+	
 	public var types:Map<String, Dynamic> = [];
 
 	public function new() {}

--- a/rulescript/Context.hx
+++ b/rulescript/Context.hx
@@ -13,6 +13,11 @@ import rulescript.types.ScriptedType;
 class Context
 {
 	public var sharedVariables:Map<String, Dynamic> = []; 
+
+	public function resetVariables():Void
+	{
+		sharedVariables = [];// yuhuh -orbl
+	}
 	
 	public var types:Map<String, Dynamic> = [];
 

--- a/rulescript/Tools.hx
+++ b/rulescript/Tools.hx
@@ -119,19 +119,6 @@ class Tools
 		#end
 	}
 
-	public static function makeBoolExpr(v:Bool):Expr {
-		#if hscriptPos
-		return {
-			e: EIdent(v ? "true" : "false"),
-			pmin: 0, pmax: 0,
-			origin: "rulescript",
-			line: 0
-		};
-		#else
-		return EIdent(v);
-		#end
-	}
-
 	public static function moduleDeclsToExpr(moduleDecls:Array<ModuleDecl>, ?parameters:{?isScriptedClass:Bool, ?fieldFilter:FieldDecl->Bool}):Expr
 	{
 		final fields:Array<Expr> = [];

--- a/rulescript/Tools.hx
+++ b/rulescript/Tools.hx
@@ -14,19 +14,6 @@ import rulescript.types.Typedefs;
 #end
 class Tools
 {
-	public static function makeBoolExpr(v:Bool):Expr {
-		#if hscriptPos
-		return {
-			e: EIdent(v ? "true" : "false"),
-			pmin: 0, pmax: 0,
-			origin: "rulescript",
-			line: 0
-		};
-		#else
-		return EIdent(v);
-		#end
-	}
-	
 	static var _printer:Printer = new Printer();
 
 	inline public static function exprToString(expr:Expr):String

--- a/rulescript/Tools.hx
+++ b/rulescript/Tools.hx
@@ -14,6 +14,19 @@ import rulescript.types.Typedefs;
 #end
 class Tools
 {
+	public static function makeBoolExpr(v:Bool):Expr {
+		#if hscriptPos
+		return {
+			e: EIdent(v ? "true" : "false"),
+			pmin: 0, pmax: 0,
+			origin: "rulescript",
+			line: 0
+		};
+		#else
+		return EIdent(v);
+		#end
+	}
+	
 	static var _printer:Printer = new Printer();
 
 	inline public static function exprToString(expr:Expr):String

--- a/rulescript/Tools.hx
+++ b/rulescript/Tools.hx
@@ -119,6 +119,19 @@ class Tools
 		#end
 	}
 
+	public static function makeBoolExpr(v:Bool):Expr {
+		#if hscriptPos
+		return {
+			e: EIdent(v ? "true" : "false"),
+			pmin: 0, pmax: 0,
+			origin: "rulescript",
+			line: 0
+		};
+		#else
+		return EIdent(v);
+		#end
+	}
+
 	public static function moduleDeclsToExpr(moduleDecls:Array<ModuleDecl>, ?parameters:{?isScriptedClass:Bool, ?fieldFilter:FieldDecl->Bool}):Expr
 	{
 		final fields:Array<Expr> = [];

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -258,46 +258,73 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 					obj = get(obj, path[currentField]);
 
 				return obj;
-			case EMeta(name, args, e) if (onMeta != null):
-				return onMeta(name, args, e);
-			case EVar(n, _, e, global, _, _public, _static):
+			case EMeta(n, args, e):
+				// n:String, args:Array<Expr>, e:Expr
+				return switch (n) {
+					case 'rs_accessModifier':
+						var ffun:Bool = false;
+						
+						final n:Null<String> = switch (e.e) {
+							case EFunction(_, _, n): ffun = true; n;
+							case EProp(n, _, _, _, _, _): n;
+							case EVar(n, _, _, _, _): n;
+							default: null;
+						};
+
+						if (n == null)
+							error(ECustom('Unable to determine the method name for @rs_accessModifier'));
+						if (args.length > 3)
+							error(ECustom('@rs_accessModifier requires three boolean arguments: (isGlobal, isPublic, and isStatic)'));
+
+						// what does `global` even do???
+						final isGlobal:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false, 
+						isPublic:Bool = (args.length > 1) ? Tools.exprToString(args[1]) == "true" : false,
+						isStatic:Bool = (args.length > 2) ? Tools.exprToString(args[2]) == "true" : false;
+
+						final __expr:Dynamic = this.expr(e);
+						if (ffun) {
+							// public & static functions
+							if (depth == 0) {
+								if (isStatic || isPublic)
+									(isStatic ? context.staticVariables : context.publicVariables).set(n, this.exprReturn(e));
+							}
+						} else {
+							// public & static variable
+							if (isStatic) {
+								if (context != null && !context.staticVariables.exists(n)) {
+									context.staticVariables.set(n, locals[n].r);
+								}
+							} else if (isPublic) {
+								if (context != null && !context.publicVariables.exists(n)) {
+									context.publicVariables.set(n, locals[n].r);
+								}
+							}
+						}
+						__expr;
+					default:
+						(onMeta != null) ? onMeta(n, args, e) : this.expr(e);
+				}
+	
+
+			case EVar(n, _, e, global, _):
 				if (global) {
-                    if(_static) {
-						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, (e != null ? this.expr(e) : null));
-						return null;
-					}
-					((_public) ? context.publicVariables : variables).set(n, (e != null ? this.expr(e) : null));
+					if(!context.staticVariables.exists(n) && !context.publicVariables.exists(n)) 
+						variables.set(n, (e == null) ? null : this.expr(e));
                 }
 				else {
 					declared.push({n: n, old: locals.get(n)});
 					locals.set(n, {r: (e == null) ? null : this.expr(e)});
-                    if(_static) {
-						if(!context.staticVariables.exists(n))
-							context.staticVariables.set(n, locals[n].r);
-						return null;
-					} else if(_public)
-						context.publicVariables.set(n, locals[n].r);
 				}
 				return null;
-			case EProp(n, g, s, type, e, global, _public, _static):
+
+			case EProp(n, g, s, type, e, global):
 				var prop = createScriptProperty(n, g, s, type);
-				if (global) {
-					if(_static) {
-						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, prop);
-						return null;
-					}
-					(_public ? context.publicVariables : variables).set(n, prop);
-				}
-				else {
+				if (global)
+					variables.set(n, prop);
+				else
+				{
 					declared.push({n: n, old: locals.get(n)});
 					locals.set(n, {r: prop});
-
-					if(_static) {
-						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, prop);	
-						return null;
-					}
-					if(_public == true)
-						context.publicVariables.set(n, prop);
 				}
 				if (e != null)
 					prop._lazyValue = () -> this.expr(e);
@@ -365,7 +392,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 						return this.expr(e);
 				}
 
-			case EFunction(params, fexpr, name, _, _public, _static):
+		case EFunction(params, fexpr, name, _):
 				if (name == 'new')
 					__constructor = expr;
 
@@ -468,12 +495,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				{
 					if (depth == 0)
 					{
-						if(_static || _public)
-							(_static ? context.staticVariables : context.publicVariables).set(name, f);
-						else {
-							// global function
-							variables.set(name, f);
-						}
+						// global function
+						variables.set(name, f);
 					}
 					else
 					{

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -291,6 +291,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 							this.expr(e);
 
 							(isStatic ? context.staticVariables : context.publicVariables).set(n, resolve(n));
+						} else {
+							this.expr(e);
 						}
 
 						null;

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -55,6 +55,11 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		imports = [];
 		usings = [];
 		typePaths = [];
+
+		if(context!=null) {
+			context.publicVariables = []; // yuhuh -orbl
+			context.staticVariables = [];
+		}
 	}
 
 	override public function posInfos():haxe.PosInfos
@@ -84,6 +89,12 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		if (id == 'super' && superInstance != null)
 			return superInstance;
 
+		if (context != null) {
+			// PUBLIC & STATIC VARIABLES
+			if (context.publicVariables.exists(id)) return context.publicVariables.get(id);
+			if (context.staticVariables.exists(id)) return context.staticVariables.get(id);
+		}
+		
 		var l:Dynamic = locals.get(id);
 		if (l != null)
 			return getScriptProp(l.r);
@@ -132,7 +143,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 	override function setVar(name:String, v:Dynamic)
 	{
-		if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
+		if (context.staticVariables.exists(name)) context.staticVariables.set(name, v);
+		else if (context.publicVariables.exists(name)) context.publicVariables.set(name, v);
+		else if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
 		else
 		{
@@ -213,7 +226,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case ETypeVarPath(path):
 				var id:String = path[0];
 
-				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id'))
+				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id') && !context.staticVariables.exists(id) && !context.publicVariables.exists(id))
 				{
 					final typePath:String = path.join('.');
 
@@ -247,32 +260,49 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				return obj;
 			case EMeta(name, args, e) if (onMeta != null):
 				return onMeta(name, args, e);
-			case EVar(n, _, e, global, _):
-				if (global)
-					variables.set(n, (e == null) ? null : this.expr(e));
-				else
-				{
+			case EVar(n, _, e, global, _, _public, _static):
+				if (global) {
+                    if(_static) {
+						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, (e != null ? this.expr(e) : null));
+						return null;
+					}
+					((_public) ? context.publicVariables : variables).set(n, (e != null ? this.expr(e) : null));
+                }
+				else {
 					declared.push({n: n, old: locals.get(n)});
 					locals.set(n, {r: (e == null) ? null : this.expr(e)});
+                    if(_static) {
+						if(!context.staticVariables.exists(n))
+							context.staticVariables.set(n, locals[n].r);
+						return null;
+					} else if(_public)
+						context.publicVariables.set(n, locals[n].r);
 				}
 				return null;
-			case EProp(n, g, s, type, e, global):
+			case EProp(n, g, s, type, e, global, _public, _static):
 				var prop = createScriptProperty(n, g, s, type);
-				if (global)
-					variables.set(n, prop);
-				else
-				{
+				if (global) {
+					if(_static) {
+						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, prop);
+						return null;
+					}
+					(_public ? context.publicVariables : variables).set(n, prop);
+				}
+				else {
 					declared.push({n: n, old: locals.get(n)});
 					locals.set(n, {r: prop});
+
+					if(_static) {
+						if(!context.staticVariables.exists(n)) context.staticVariables.set(n, prop);	
+						return null;
+					}
+					if(_public == true)
+						context.publicVariables.set(n, prop);
 				}
 				if (e != null)
 					prop._lazyValue = () -> this.expr(e);
 				return null;
-			case EIdent(id):
-				var l = locals.get(id);
-				if (l != null)
-					return getScriptProp(l.r);
-				return resolve(id);
+			case EIdent(id): return resolve(id);//wuh
 			case ECall(e, params):
 				var args = new Array();
 				for (p in params)
@@ -334,7 +364,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 					default:
 						return this.expr(e);
 				}
-			case EFunction(params, fexpr, name, _):
+
+			case EFunction(params, fexpr, name, _, _public, _static):
 				if (name == 'new')
 					__constructor = expr;
 
@@ -437,8 +468,12 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				{
 					if (depth == 0)
 					{
-						// global function
-						variables.set(name, f);
+						if(_static || _public)
+							(_static ? context.staticVariables : context.publicVariables).set(name, f);
+						else {
+							// global function
+							variables.set(name, f);
+						}
 					}
 					else
 					{

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -270,24 +270,21 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 						if (n == null)
 							error(ECustom('Unable to determine the method name for @:contextValue'));
-						if (args.length > 3)
-							error(ECustom('@:contextValue requires three boolean arguments: (isGlobal, isPublic, and isStatic)'));
+						if (args.length > 1)
+							error(ECustom('@:contextValue requires one boolean arguments: isShared'));
 
-						// what does `global` even do???
-						final isGlobal:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false, 
-						isPublic:Bool = (args.length > 1) ? Tools.exprToString(args[1]) == "true" : false,
-						isStatic:Bool = (args.length > 2) ? Tools.exprToString(args[2]) == "true" : false;
+						final isShared:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false;
 
 						final __expr:Dynamic = this.expr(e);
 						if (ffun) {
-							// public & static functions
+							// shared functions
 							if (depth == 0) {
-								if (isStatic || isPublic)
+								if (isShared)
 									context.sharedVariables.set(n, this.exprReturn(e));
 							}
 						} else {
 							// shared variables
-							if (isStatic || isPublic) {
+							if (isShared) {
 								if (context != null && !context.sharedVariables.exists(n)) {
 									context.sharedVariables.set(n, locals[n].r);
 								}

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -91,11 +91,14 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 		if (v == null && !variables.exists(id))
 		{
-			v = Reflect.getProperty(superInstance, id) ?? error(EUnknownVariable(id));
+			v = Reflect.getProperty(superInstance, id) ;//?? error(EUnknownVariable(id)); 
 
 			// SHARED VARIABLES
-			if (v == null && context != null && context.sharedVariables.exists(id))
-				v = context.sharedVariables.get(id);
+			if (v == null && context != null){
+				if(context.staticVariables.exists(id)) v = context.staticVariables.get(id);
+				if(context.publicVariables.exists(id)) v = context.publicVariables.get(id);
+			}
+			v ?? error(EUnknownVariable(id)); // fixes - orbl
 		}
 
 		return v;
@@ -141,8 +144,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 	{
 		if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
-		else if (context.sharedVariables.exists(name))
-			context.sharedVariables.set(name, v);
+		else if (context.staticVariables.exists(name)) context.staticVariables.set(name, v);
+		else if (context.publicVariables.exists(name)) context.publicVariables.set(name, v);
 		else
 		{
 			var lastValue = variables.get(name);
@@ -223,7 +226,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				var id:String = path[0];
 
 				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id')
-					&& !context.sharedVariables.exists(id))
+					&& !context.staticVariables.exists(id) && !context.publicVariables.exists(id))
 				{
 					final typePath:String = path.join('.');
 
@@ -270,15 +273,19 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 							default: null;
 						};
 
+						final isPublic:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false,
+						isStatic:Bool = (args.length > 1) ? Tools.exprToString(args[1]) == "true" : false;
+
 						if (isFunction && depth == 0)
 						{
-							return context.sharedVariables[n] = this.expr(e);
+							if (isStatic || isPublic)
+								return (isStatic ? context.staticVariables : context.publicVariables)[n] = this.expr(e);
 						}
 						else
 						{
 							this.expr(e);
 
-							context.sharedVariables.set(n, resolve(n));
+							(isStatic ? context.staticVariables : context.publicVariables).set(n, resolve(n));
 						}
 
 						null;
@@ -289,7 +296,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case EVar(n, _, e, global, _):
 				if (global)
 				{
-					if (!context.sharedVariables.exists(n))
+					if (!context.staticVariables.exists(n) && !context.publicVariables.exists(n))
 						variables.set(n, (e == null) ? null : this.expr(e));
 				}
 				else

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -286,7 +286,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 						{
 							return (isStatic ? context.staticVariables : context.publicVariables)[n] = this.expr(e);
 						}
-						else
+						else if(depth == 0)
 						{
 							this.expr(e);
 

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -261,7 +261,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case EMeta(n, args, e):
 				// n:String, args:Array<Expr>, e:Expr
 				return switch (n) {
-					case 'rs_accessModifier':
+					case ':contextValue':
 						var ffun:Bool = false;
 						
 						final n:Null<String> = switch (e.e) {
@@ -272,9 +272,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 						};
 
 						if (n == null)
-							error(ECustom('Unable to determine the method name for @rs_accessModifier'));
+							error(ECustom('Unable to determine the method name for @:contextValue'));
 						if (args.length > 3)
-							error(ECustom('@rs_accessModifier requires three boolean arguments: (isGlobal, isPublic, and isStatic)'));
+							error(ECustom('@:contextValue requires three boolean arguments: (isGlobal, isPublic, and isStatic)'));
 
 						// what does `global` even do???
 						final isGlobal:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false, 

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -149,9 +149,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 	{
 		if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
-		else if (context.staticVariables.exists(name))
+		else if (context != null && context.staticVariables.exists(name))
 			context.staticVariables.set(name, v);
-		else if (context.publicVariables.exists(name))
+		else if (context != null && context.publicVariables.exists(name))
 			context.publicVariables.set(name, v);
 		else
 		{
@@ -232,8 +232,9 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case ETypeVarPath(path):
 				var id:String = path[0];
 
-				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id')
-					&& !context.staticVariables.exists(id) && !context.publicVariables.exists(id))
+				if ((!locals.exists(id) && !variables.exists(id))
+					&& (!superFields.contains(id) && !superFields.contains('get_$id'))
+					&& (context != null && !context.staticVariables.exists(id) && !context.publicVariables.exists(id)))
 				{
 					final typePath:String = path.join('.');
 
@@ -286,12 +287,14 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 						{
 							return (isStatic ? context.staticVariables : context.publicVariables)[n] = this.expr(e);
 						}
-						else if(depth == 0)
+						else if (depth == 0)
 						{
 							this.expr(e);
 
 							(isStatic ? context.staticVariables : context.publicVariables).set(n, resolve(n));
-						} else {
+						}
+						else
+						{
 							this.expr(e);
 						}
 
@@ -303,7 +306,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case EVar(n, _, e, global, _):
 				if (global)
 				{
-					if (!context.staticVariables.exists(n) && !context.publicVariables.exists(n))
+					if (context == null || (!context.staticVariables.exists(n) && !context.publicVariables.exists(n)))
 						variables.set(n, (e == null) ? null : this.expr(e));
 				}
 				else

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -91,14 +91,19 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 		if (v == null && !variables.exists(id))
 		{
-			v = Reflect.getProperty(superInstance, id) ;//?? error(EUnknownVariable(id)); 
+			v = Reflect.getProperty(superInstance, id);
 
 			// SHARED VARIABLES
-			if (v == null && context != null){
-				if(context.staticVariables.exists(id)) v = context.staticVariables.get(id);
-				if(context.publicVariables.exists(id)) v = context.publicVariables.get(id);
+			if (v == null && context != null)
+			{
+				if (context.staticVariables.exists(id))
+					v = context.staticVariables.get(id);
+				if (context.publicVariables.exists(id))
+					v = context.publicVariables.get(id);
 			}
-			v ?? error(EUnknownVariable(id)); // fixes - orbl
+
+			if (v == null)
+				error(EUnknownVariable(id)); // fixes - orbl
 		}
 
 		return v;
@@ -144,8 +149,10 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 	{
 		if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
-		else if (context.staticVariables.exists(name)) context.staticVariables.set(name, v);
-		else if (context.publicVariables.exists(name)) context.publicVariables.set(name, v);
+		else if (context.staticVariables.exists(name))
+			context.staticVariables.set(name, v);
+		else if (context.publicVariables.exists(name))
+			context.publicVariables.set(name, v);
 		else
 		{
 			var lastValue = variables.get(name);
@@ -273,13 +280,11 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 							default: null;
 						};
 
-						final isPublic:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false,
-						isStatic:Bool = (args.length > 1) ? Tools.exprToString(args[1]) == "true" : false;
+						final isStatic:Bool = args.length > 0 && args[0].getExpr().match(EIdent('static'));
 
 						if (isFunction && depth == 0)
 						{
-							if (isStatic || isPublic)
-								return (isStatic ? context.staticVariables : context.publicVariables)[n] = this.expr(e);
+							return (isStatic ? context.staticVariables : context.publicVariables)[n] = this.expr(e);
 						}
 						else
 						{

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -84,18 +84,20 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		if (id == 'super' && superInstance != null)
 			return superInstance;
 
-		if (context != null) {
-			// SHARED VARIABLES
-			if (context.sharedVariables.exists(id)) return context.sharedVariables.get(id);
-		}
-		
 		var l:Dynamic = locals.get(id);
 		if (l != null)
 			return getScriptProp(l.r);
 		var v:Dynamic = getScriptProp(variables.get(id));
 
 		if (v == null && !variables.exists(id))
+		{
 			v = Reflect.getProperty(superInstance, id) ?? error(EUnknownVariable(id));
+
+			// SHARED VARIABLES
+			if (v == null && context != null && context.sharedVariables.exists(id))
+				v = context.sharedVariables.get(id);
+		}
+
 		return v;
 	}
 
@@ -137,9 +139,10 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 	override function setVar(name:String, v:Dynamic)
 	{
-		if (context.sharedVariables.exists(name)) context.sharedVariables.set(name, v);
-		else if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
+		if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
+		else if (context.sharedVariables.exists(name))
+			context.sharedVariables.set(name, v);
 		else
 		{
 			var lastValue = variables.get(name);
@@ -219,7 +222,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case ETypeVarPath(path):
 				var id:String = path[0];
 
-				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id') && !context.sharedVariables.exists(id))
+				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id')
+					&& !context.sharedVariables.exists(id))
 				{
 					final typePath:String = path.join('.');
 
@@ -252,52 +256,44 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 				return obj;
 			case EMeta(n, args, e):
-				// n:String, args:Array<Expr>, e:Expr
-				return switch (n) {
-					case ':contextValue':
-						var ffun:Bool = false;
-						
-						final n:Null<String> = switch (e.e) {
-							case EFunction(_, _, n): ffun = true; n;
-							case EProp(n, _, _, _, _, _): n;
-							case EVar(n, _, _, _, _): n;
+				return switch (n)
+				{
+					case ':contextValue' if (context != null):
+						var isFunction:Bool = false;
+
+						final n:Null<String> = switch (Tools.getExpr(e))
+						{
+							case EFunction(_, _, n):
+								isFunction = true;
+								n;
+							case EProp(n, _), EVar(n, _): n;
 							default: null;
 						};
 
-						if (n == null)
-							error(ECustom('Unable to determine the method name for @:contextValue'));
-						if (args.length > 1)
-							error(ECustom('@:contextValue requires one boolean arguments: isShared'));
-
-						final isShared:Bool = (args.length > 0) ? Tools.exprToString(args[0]) == "true" : false;
-
-						final __expr:Dynamic = this.expr(e);
-						if (ffun) {
-							// shared functions
-							if (depth == 0) {
-								if (isShared)
-									context.sharedVariables.set(n, this.exprReturn(e));
-							}
-						} else {
-							// shared variables
-							if (isShared) {
-								if (context != null && !context.sharedVariables.exists(n)) {
-									context.sharedVariables.set(n, locals[n].r);
-								}
-							}
+						if (isFunction && depth == 0)
+						{
+							return context.sharedVariables[n] = this.expr(e);
 						}
-						__expr;
+						else
+						{
+							this.expr(e);
+
+							context.sharedVariables.set(n, resolve(n));
+						}
+
+						null;
 					default:
 						(onMeta != null) ? onMeta(n, args, e) : this.expr(e);
 				}
-	
 
 			case EVar(n, _, e, global, _):
-				if (global) {
-					if(!context.sharedVariables.exists(n)) 
+				if (global)
+				{
+					if (!context.sharedVariables.exists(n))
 						variables.set(n, (e == null) ? null : this.expr(e));
-                }
-				else {
+				}
+				else
+				{
 					declared.push({n: n, old: locals.get(n)});
 					locals.set(n, {r: (e == null) ? null : this.expr(e)});
 				}
@@ -315,7 +311,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 				if (e != null)
 					prop._lazyValue = () -> this.expr(e);
 				return null;
-			case EIdent(id): return resolve(id);//wuh
+			case EIdent(id):
+				return resolve(id); // wuh
 			case ECall(e, params):
 				var args = new Array();
 				for (p in params)
@@ -378,7 +375,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 						return this.expr(e);
 				}
 
-		case EFunction(params, fexpr, name, _):
+			case EFunction(params, fexpr, name, _):
 				if (name == 'new')
 					__constructor = expr;
 
@@ -890,7 +887,8 @@ class RuleScriptInterpAccess extends RuleScriptAccess
 		return interp.variables[name];
 	}
 
-	override function posInfos():haxe.PosInfos {
+	override function posInfos():haxe.PosInfos
+	{
 		return interp.posInfos();
 	}
 

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -57,8 +57,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		typePaths = [];
 
 		if(context!=null) {
-			context.publicVariables = []; // yuhuh -orbl
-			context.staticVariables = [];
+			context.sharedVariables = []; // yuhuh -orbl
 		}
 	}
 
@@ -90,9 +89,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			return superInstance;
 
 		if (context != null) {
-			// PUBLIC & STATIC VARIABLES
-			if (context.publicVariables.exists(id)) return context.publicVariables.get(id);
-			if (context.staticVariables.exists(id)) return context.staticVariables.get(id);
+			// SHARED VARIABLES
+			if (context.sharedVariables.exists(id)) return context.sharedVariables.get(id);
 		}
 		
 		var l:Dynamic = locals.get(id);
@@ -143,8 +141,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 	override function setVar(name:String, v:Dynamic)
 	{
-		if (context.staticVariables.exists(name)) context.staticVariables.set(name, v);
-		else if (context.publicVariables.exists(name)) context.publicVariables.set(name, v);
+		if (context.sharedVariables.exists(name)) context.sharedVariables.set(name, v);
 		else if (superInstance != null && (superFields.contains(name) || superFields.contains('set_' + name)))
 			Reflect.setProperty(superInstance, name, v);
 		else
@@ -226,7 +223,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 			case ETypeVarPath(path):
 				var id:String = path[0];
 
-				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id') && !context.staticVariables.exists(id) && !context.publicVariables.exists(id))
+				if (!locals.exists(id) && !variables.exists(id) && !superFields.contains(id) && !superFields.contains('get_$id') && !context.sharedVariables.exists(id))
 				{
 					final typePath:String = path.join('.');
 
@@ -286,17 +283,13 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 							// public & static functions
 							if (depth == 0) {
 								if (isStatic || isPublic)
-									(isStatic ? context.staticVariables : context.publicVariables).set(n, this.exprReturn(e));
+									context.sharedVariables.set(n, this.exprReturn(e));
 							}
 						} else {
-							// public & static variable
-							if (isStatic) {
-								if (context != null && !context.staticVariables.exists(n)) {
-									context.staticVariables.set(n, locals[n].r);
-								}
-							} else if (isPublic) {
-								if (context != null && !context.publicVariables.exists(n)) {
-									context.publicVariables.set(n, locals[n].r);
+							// shared variables
+							if (isStatic || isPublic) {
+								if (context != null && !context.sharedVariables.exists(n)) {
+									context.sharedVariables.set(n, locals[n].r);
 								}
 							}
 						}
@@ -308,7 +301,7 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 			case EVar(n, _, e, global, _):
 				if (global) {
-					if(!context.staticVariables.exists(n) && !context.publicVariables.exists(n)) 
+					if(!context.sharedVariables.exists(n)) 
 						variables.set(n, (e == null) ? null : this.expr(e));
                 }
 				else {

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -55,10 +55,6 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 		imports = [];
 		usings = [];
 		typePaths = [];
-
-		if(context!=null) {
-			context.sharedVariables = []; // yuhuh -orbl
-		}
 	}
 
 	override public function posInfos():haxe.PosInfos

--- a/rulescript/macro/ExprMacro.hx
+++ b/rulescript/macro/ExprMacro.hx
@@ -14,7 +14,7 @@ class ExprMacro
 
 		var pos = Context.currentPos();
 
-		fields = fields.filter(field -> !([ "EVar", "EFunction", "ENew" ]).contains(field.name));
+		fields = fields.filter(field -> !([ "EVar", "ENew" ]).contains(field.name));
 
 		var newFields:Map<String, Expr> = [
 			'EPackage' => macro function(path:String) {},
@@ -23,14 +23,12 @@ class ExprMacro
 			'EUsing' => macro function(name:String) {},
 
 			'ENew' => macro function(cl:String, params:Array<Expr>, ?typeParams:Array<CType>) {},
-			'EVar' => macro function(n:String, ?t:CType, ?e:Expr, ?global:Bool, ?isFinal:Bool, ?_public:Bool, ?_static:Bool) {},
-			'EProp' => macro function(n:String, g:String, s:String, ?t:CType, ?e:Expr, ?global:Bool, ?_public:Bool, ?_static:Bool) {},
+			'EVar' => macro function(n:String, ?t:CType, ?e:Expr, ?global:Bool, ?isFinal:Bool) {},
+			'EProp' => macro function(n:String, g:String, s:String, ?t:CType, ?e:Expr, ?global:Bool) {},
 			'ETypeVarPath' => macro function(path:Array<String>) {},
 			'EUntyped' => macro function(e:Expr) {},
 			'ECast' => macro function(e:Expr, ?t:CType) {},
 			'EMapDecl' => macro function(exprs:Array<Expr>) {},
-
-			'EFunction' => macro function(args:Array<Argument>, e:Expr, ?name:String, ?ret:CType, ?_public:Bool, ?_static:Bool) {}
 		];
 
 		for (key => value in newFields)

--- a/rulescript/macro/ExprMacro.hx
+++ b/rulescript/macro/ExprMacro.hx
@@ -14,7 +14,7 @@ class ExprMacro
 
 		var pos = Context.currentPos();
 
-		fields = fields.filter(field -> !([ "EVar", "ENew" ]).contains(field.name));
+		fields = fields.filter(field -> !(["EVar", "ENew"]).contains(field.name));
 
 		var newFields:Map<String, Expr> = [
 			'EPackage' => macro function(path:String) {},
@@ -28,7 +28,7 @@ class ExprMacro
 			'ETypeVarPath' => macro function(path:Array<String>) {},
 			'EUntyped' => macro function(e:Expr) {},
 			'ECast' => macro function(e:Expr, ?t:CType) {},
-			'EMapDecl' => macro function(exprs:Array<Expr>) {},
+			'EMapDecl' => macro function(exprs:Array<Expr>) {}
 		];
 
 		for (key => value in newFields)

--- a/rulescript/macro/ExprMacro.hx
+++ b/rulescript/macro/ExprMacro.hx
@@ -14,9 +14,7 @@ class ExprMacro
 
 		var pos = Context.currentPos();
 
-		for (field in fields)
-			if (field.name == 'EVar' || field.name == 'ENew')
-				fields.remove(field);
+		fields = fields.filter(field -> !([ "EVar", "EFunction", "ENew" ]).contains(field.name));
 
 		var newFields:Map<String, Expr> = [
 			'EPackage' => macro function(path:String) {},
@@ -25,13 +23,14 @@ class ExprMacro
 			'EUsing' => macro function(name:String) {},
 
 			'ENew' => macro function(cl:String, params:Array<Expr>, ?typeParams:Array<CType>) {},
-			'EVar' => macro function(n:String, ?t:CType, ?e:Expr, ?global:Bool, ?isFinal:Bool) {},
-			'EProp' => macro function(n:String, g:String, s:String, ?t:CType, ?e:Expr, ?global:Bool) {},
+			'EVar' => macro function(n:String, ?t:CType, ?e:Expr, ?global:Bool, ?isFinal:Bool, ?_public:Bool, ?_static:Bool) {},
+			'EProp' => macro function(n:String, g:String, s:String, ?t:CType, ?e:Expr, ?global:Bool, ?_public:Bool, ?_static:Bool) {},
 			'ETypeVarPath' => macro function(path:Array<String>) {},
 			'EUntyped' => macro function(e:Expr) {},
 			'ECast' => macro function(e:Expr, ?t:CType) {},
-			'EMapDecl' => macro function(exprs:Array<Expr>) {}
+			'EMapDecl' => macro function(exprs:Array<Expr>) {},
 
+			'EFunction' => macro function(args:Array<Argument>, e:Expr, ?name:String, ?ret:CType, ?_public:Bool, ?_static:Bool) {}
 		];
 
 		for (key => value in newFields)

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -792,7 +792,7 @@ class HScriptParser extends hscript.Parser
 					push(tk);
 				var expr = (props == null) ? EVar(ident, t, e, false, id == "final") : EProp(ident, props.get, props.set, t, e, null);
 				if (__nextPub || __nextStatic) {
-					mk(EMeta("rs_accessModifier", [
+					mk(EMeta(":contextValue", [
 						Tools.makeBoolExpr(false),
 						Tools.makeBoolExpr(__nextPub),
 						Tools.makeBoolExpr(__nextStatic)
@@ -808,7 +808,7 @@ class HScriptParser extends hscript.Parser
 				final inf = parseFunctionDecl();
 
 				if (__nextStatic || __nextPub) {
-					final __exprDef = EMeta("rs_accessModifier", [
+					final __exprDef = EMeta(":contextValue", [
 						Tools.makeBoolExpr(false),
 						Tools.makeBoolExpr(__nextPub),
 						Tools.makeBoolExpr(__nextStatic)

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -17,6 +17,8 @@ typedef HxParserParams =
 	var ?allowUsing:Bool;
 	var ?allowStringInterpolation:Bool;
 	var ?allowTypePath:Bool;
+	var ?allowPublicVariables:Bool;
+	var ?allowStaticVariables:Bool;
 }
 
 enum HxParserMode
@@ -78,17 +80,21 @@ class HxParser extends Parser
 			allowImport: true,
 			allowUsing: true,
 			allowStringInterpolation: true,
+			allowPublicVariables: true,
+			allowStaticVariables: true,
 			allowTypePath: true
 		});
 	}
 
 	@:deprecated
-	public function setParams(?allowJSON:Bool, ?allowMetadata:Bool, ?allowTypes:Bool, ?allowStringInterpolation:Bool, ?allowTypePath:Bool)
+	public function setParams(?allowJSON:Bool, ?allowMetadata:Bool, ?allowTypes:Bool, ?allowStringInterpolation:Bool, ?allowTypePath:Bool, ?allowPublicVariables:Bool, ?allowStaticVariables:Bool)
 	{
 		parser.allowJSON = allowJSON;
 		parser.allowMetadata = allowMetadata;
 		parser.allowTypes = allowTypes;
 		parser.allowStringInterpolation = allowStringInterpolation;
+		parser.allowPublicVariables = allowPublicVariables;
+		parser.allowStaticVariables = allowStaticVariables;
 		parser.allowTypePath = allowTypePath;
 	}
 
@@ -159,6 +165,9 @@ class HScriptParser extends hscript.Parser
 {
 	public var mode:HxParserMode;
 
+	public var allowPublicVariables:Bool = true;
+	public var allowStaticVariables:Bool = true;
+
 	public var allowPackage:Bool = true;
 	public var allowImport:Bool = true;
 	public var allowUsing:Bool = true;
@@ -172,6 +181,9 @@ class HScriptParser extends hscript.Parser
 	static inline final tokenMax:Int = 0;
 	#end
 
+	private var __nextStatic:Bool = false; 
+	private var __nextPub:Bool = false;
+	
 	public function new()
 	{
 		super();
@@ -775,21 +787,14 @@ class HScriptParser extends hscript.Parser
 				else
 					push(tk);
 
-				if (props == null)
-					mk(EVar(ident, t, e, false, id == 'final'), p1, (e == null) ? tokenMax : pmax(e));
-				else
-					mk(EProp(ident, props.get, props.set, t, e), p1, (e == null) ? tokenMax : pmax(e));
-			case 'public' if (mode == DEFAULT):
-				final e:Expr = parseExpr();
+				mk(props == null ? EVar(ident, t, e, false, id == 'final', __nextPub, __nextStatic) : EProp(ident, props.get, props.set, t, e, null, __nextPub, __nextStatic), p1, (e == null) ? tokenMax : pmax(e));
 
-				switch (e.getExpr())
-				{
-					case EVar(n, t, e, false, isFinal):
-						mk(EVar(n, t, e, true, isFinal), p1, pmax(e));
-					case EProp(n, g, s, t, e, false):
-						mk(EProp(n, g, s, t, e, true), p1, pmax(e));
-					default: unexpected(TId(id));
-				}
+			case "function":
+				var name:String = null;
+				final tk = token();
+				switch tk { case TId(id): name = id; default: push(tk); }
+				final inf= parseFunctionDecl();
+				mk(EFunction(inf.args, inf.body, name, inf.ret, __nextPub, __nextStatic), p1, pmax(inf.body));
 			case 'untyped':
 				mk(EUntyped(parseExpr()));
 			case 'cast':
@@ -857,9 +862,31 @@ class HScriptParser extends hscript.Parser
 
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
+			case "static" if (mode == DEFAULT && allowStaticVariables):
+				parseStatPubStruc(id);
+			case "public" if (mode == DEFAULT && allowPublicVariables):
+				parseStatPubStruc(id);
 			default:
 				super.parseStructure(id);
 		}
+	}
+
+	// i'm lazy okay, leave me alone :sob:
+	// there is defiantly a easier and better way to do this, butttt, ehh -orbl
+	function parseStatPubStruc(id:String):Expr {
+			final __isstatic:Bool  = id == "static", __ispublic:Bool  = id == "public";
+			if (__isstatic) __nextStatic = true; if (__ispublic) __nextPub = true;
+			var result:Expr;
+			final __nextToken:Token = token();
+			switch (__nextToken) {
+				case TId("function"), TId("public"), TId("static"), TId("final"), TId("override"), TId("var"):
+					result = parseStructure(switch(__nextToken) { case TId(n): n; default: ""; });
+				default:
+					unexpected(__nextToken);
+					result = null;
+			}
+			if (__isstatic) __nextStatic = false; if (__ispublic) __nextPub = false;
+			return result;
 	}
 
 	function parseStringInterpolation():Expr

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -123,6 +123,12 @@ class HxParser extends Parser
 
 		if (parameters.allowTypePath != null)
 			parser.allowTypePath = parameters.allowTypePath;
+
+		if(parameters.allowPublicVariables != null)
+			parser.allowPublicVariables = parameters.allowPublicVariables;
+		
+		if(parameters.allowStaticVariables != null)
+			parser.allowStaticVariables = parameters.allowStaticVariables;
 	}
 
 	override public function parse(code:String):Expr

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -87,14 +87,12 @@ class HxParser extends Parser
 	}
 
 	@:deprecated
-	public function setParams(?allowJSON:Bool, ?allowMetadata:Bool, ?allowTypes:Bool, ?allowStringInterpolation:Bool, ?allowTypePath:Bool, ?allowPublicVariables:Bool, ?allowStaticVariables:Bool)
+	public function setParams(?allowJSON:Bool, ?allowMetadata:Bool, ?allowTypes:Bool, ?allowStringInterpolation:Bool, ?allowTypePath:Bool)
 	{
 		parser.allowJSON = allowJSON;
 		parser.allowMetadata = allowMetadata;
 		parser.allowTypes = allowTypes;
 		parser.allowStringInterpolation = allowStringInterpolation;
-		parser.allowPublicVariables = allowPublicVariables;
-		parser.allowStaticVariables = allowStaticVariables;
 		parser.allowTypePath = allowTypePath;
 	}
 

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -867,9 +867,9 @@ class HScriptParser extends hscript.Parser
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
 			case "static" if (mode == DEFAULT && allowStaticVariables):
-				parseStatPubStruc(id);
+				this.parseContextStructure(id);
 			case "public" if (mode == DEFAULT && allowPublicVariables):
-				parseStatPubStruc(id);
+				this.parseContextStructure(id);
 			default:
 				super.parseStructure(id);
 		}
@@ -877,9 +877,9 @@ class HScriptParser extends hscript.Parser
 
 	// i'm lazy okay, leave me alone :sob:
 	// there is defiantly a easier and better way to do this, butttt, ehh -orbl
-	function parseStatPubStruc(id:String):Expr {
-			final __isstatic:Bool  = id == "static", __ispublic:Bool  = id == "public";
-			if (__isstatic) __nextStatic = true; if (__ispublic) __nextPub = true;
+	function parseContextStructure(id:String):Expr {
+			final __isStatic:Bool  = id == "static", __isPublic:Bool  = id == "public";
+			if (__isStatic) __nextStatic = true; if (__isPublic) __nextPub = true;
 			var result:Expr;
 			final __nextToken:Token = token();
 			switch (__nextToken) {
@@ -889,7 +889,7 @@ class HScriptParser extends hscript.Parser
 					unexpected(__nextToken);
 					result = null;
 			}
-			if (__isstatic) __nextStatic = false; if (__ispublic) __nextPub = false;
+			if (__isStatic) __nextStatic = false; if (__isPublic) __nextPub = false;
 			return result;
 	}
 

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -17,8 +17,7 @@ typedef HxParserParams =
 	var ?allowUsing:Bool;
 	var ?allowStringInterpolation:Bool;
 	var ?allowTypePath:Bool;
-	var ?allowPublicVariables:Bool;
-	var ?allowStaticVariables:Bool;
+	var ?allowSharedVariables:Bool;
 }
 
 enum HxParserMode
@@ -80,8 +79,7 @@ class HxParser extends Parser
 			allowImport: true,
 			allowUsing: true,
 			allowStringInterpolation: true,
-			allowPublicVariables: true,
-			allowStaticVariables: true,
+			allowSharedVariables: true,
 			allowTypePath: true
 		});
 	}
@@ -122,11 +120,8 @@ class HxParser extends Parser
 		if (parameters.allowTypePath != null)
 			parser.allowTypePath = parameters.allowTypePath;
 
-		if(parameters.allowPublicVariables != null)
-			parser.allowPublicVariables = parameters.allowPublicVariables;
-		
-		if(parameters.allowStaticVariables != null)
-			parser.allowStaticVariables = parameters.allowStaticVariables;
+		if(parameters.allowSharedVariables != null)
+			parser.allowSharedVariables = parameters.allowSharedVariables;
 	}
 
 	override public function parse(code:String):Expr
@@ -169,8 +164,7 @@ class HScriptParser extends hscript.Parser
 {
 	public var mode:HxParserMode;
 
-	public var allowPublicVariables:Bool = true;
-	public var allowStaticVariables:Bool = true;
+	public var allowSharedVariables:Bool = true;
 
 	public var allowPackage:Bool = true;
 	public var allowImport:Bool = true;
@@ -891,9 +885,9 @@ class HScriptParser extends hscript.Parser
 
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
-			case "static" if (mode == DEFAULT && allowStaticVariables):
+			case "static" if (mode == DEFAULT && allowSharedVariables):
 				this.parseContextStructure(id);
-			case "public" if (mode == DEFAULT && allowPublicVariables):
+			case "public" if (mode == DEFAULT && allowSharedVariables):
 				this.parseContextStructure(id);
 			default:
 				super.parseStructure(id);

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -122,10 +122,10 @@ class HxParser extends Parser
 		if (parameters.allowTypePath != null)
 			parser.allowTypePath = parameters.allowTypePath;
 
-		if(parameters.allowStaticVariables != null)
+		if (parameters.allowStaticVariables != null)
 			parser.allowStaticVariables = parameters.allowStaticVariables;
 
-		if(parameters.allowPublicVariables != null)
+		if (parameters.allowPublicVariables != null)
 			parser.allowPublicVariables = parameters.allowPublicVariables;
 	}
 
@@ -874,22 +874,22 @@ class HScriptParser extends hscript.Parser
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
 
-			case "public" if (mode == DEFAULT && allowPublicVariables):
-				parseContext(id, p1, false, true);
-
-			case "static" if (mode == DEFAULT && allowStaticVariables):
-				parseContext(id, p1, true, false);
+			case 'public' if (mode == DEFAULT && allowPublicVariables):
+				parseContext(id, false);
+			case 'static' if (mode == DEFAULT && allowStaticVariables):
+				parseContext(id, true);
 			default:
 				super.parseStructure(id);
 		}
 	}
 
-	// my brain 🥴
-	function parseContext(id, p1, isStatic:Bool, isPublic:Bool) {
+	function parseContext(id:String, isStatic:Bool) // public if not static
+	{
 		final e:Expr = parseExpr();
-		switch (e.getExpr()) {
+		switch (e.getExpr())
+		{
 			case EVar(n, _), EProp(n, _), EFunction(_, _, n) if (n != null):
-				return mk(EMeta(':contextValue', [Tools.makeBoolExpr(isPublic), Tools.makeBoolExpr(isStatic)], e), p1, tokenMax);
+				return mk(EMeta(':contextValue', [Tools.toExpr(EIdent(isStatic ? 'static' : 'public'))], e), tokenMin, tokenMax);
 			default:
 				return unexpected(TId(id));
 		}

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -179,8 +179,7 @@ class HScriptParser extends hscript.Parser
 	static inline final tokenMax:Int = 0;
 	#end
 
-	private var __nextStatic:Bool = false; 
-	private var __nextPub:Bool = false;
+	private var __nextShared:Bool = false;
 	
 	public function new()
 	{
@@ -785,11 +784,9 @@ class HScriptParser extends hscript.Parser
 				else
 					push(tk);
 				var expr = (props == null) ? EVar(ident, t, e, false, id == "final") : EProp(ident, props.get, props.set, t, e, null);
-				if (__nextPub || __nextStatic) {
+				if (__nextShared) {
 					mk(EMeta(":contextValue", [
-						Tools.makeBoolExpr(false),
-						Tools.makeBoolExpr(__nextPub),
-						Tools.makeBoolExpr(__nextStatic)
+						Tools.makeBoolExpr(__nextShared)
 					], expr.toExpr()), p1, e == null ? tokenMax : pmax(e));
 				} else {
 					mk(expr, p1, e == null ? tokenMax : pmax(e));
@@ -801,11 +798,9 @@ class HScriptParser extends hscript.Parser
 				switch tk { case TId(id): name = id; default: push(tk); }
 				final inf = parseFunctionDecl();
 
-				if (__nextStatic || __nextPub) {
+				if (__nextShared) {
 					final __exprDef = EMeta(":contextValue", [
-						Tools.makeBoolExpr(false),
-						Tools.makeBoolExpr(__nextPub),
-						Tools.makeBoolExpr(__nextStatic)
+						Tools.makeBoolExpr(__nextShared)
 					], mk(EFunction(inf.args, inf.body, name, inf.ret)));
 
 					{
@@ -885,31 +880,29 @@ class HScriptParser extends hscript.Parser
 
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
-			case "static" if (mode == DEFAULT && allowSharedVariables):
-				this.parseContextStructure(id);
-			case "public" if (mode == DEFAULT && allowSharedVariables):
-				this.parseContextStructure(id);
+			case "static", "public"  if (mode == DEFAULT && allowSharedVariables):
+				// i'm lazy okay, leave me alone :sob:
+				// there is defiantly a easier and better way to do this, butttt, ehh -orbl
+				var result:Expr;
+				final __isShared:Bool = (id == "static" || id == "public");
+				if (__isShared) __nextShared = true;
+				final __nextToken:Token = token();
+				switch __nextToken {
+					case TId("function"), TId("public"), TId("static"), TId("final"), TId("override"), TId("var"):
+						result = parseStructure(switch __nextToken {
+							case TId(n): n;
+							default: "";
+						});
+					default:
+						unexpected(__nextToken);
+						result = null;
+				}
+
+				if (__isShared) __nextShared = false;
+				result;
 			default:
 				super.parseStructure(id);
 		}
-	}
-
-	// i'm lazy okay, leave me alone :sob:
-	// there is defiantly a easier and better way to do this, butttt, ehh -orbl
-	function parseContextStructure(id:String):Expr {
-			final __isStatic:Bool  = id == "static", __isPublic:Bool  = id == "public";
-			if (__isStatic) __nextStatic = true; if (__isPublic) __nextPub = true;
-			var result:Expr;
-			final __nextToken:Token = token();
-			switch (__nextToken) {
-				case TId("function"), TId("public"), TId("static"), TId("final"), TId("override"), TId("var"):
-					result = parseStructure(switch(__nextToken) { case TId(n): n; default: ""; });
-				default:
-					unexpected(__nextToken);
-					result = null;
-			}
-			if (__isStatic) __nextStatic = false; if (__isPublic) __nextPub = false;
-			return result;
 	}
 
 	function parseStringInterpolation():Expr

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -790,15 +790,40 @@ class HScriptParser extends hscript.Parser
 					e = parseExpr();
 				else
 					push(tk);
-
-				mk(props == null ? EVar(ident, t, e, false, id == 'final', __nextPub, __nextStatic) : EProp(ident, props.get, props.set, t, e, null, __nextPub, __nextStatic), p1, (e == null) ? tokenMax : pmax(e));
-
+				var expr = (props == null) ? EVar(ident, t, e, false, id == "final") : EProp(ident, props.get, props.set, t, e, null);
+				if (__nextPub || __nextStatic) {
+					mk(EMeta("rs_accessModifier", [
+						Tools.makeBoolExpr(false),
+						Tools.makeBoolExpr(__nextPub),
+						Tools.makeBoolExpr(__nextStatic)
+					], expr.toExpr()), p1, e == null ? tokenMax : pmax(e));
+				} else {
+					mk(expr, p1, e == null ? tokenMax : pmax(e));
+				}
+		
 			case "function":
 				var name:String = null;
 				final tk = token();
 				switch tk { case TId(id): name = id; default: push(tk); }
-				final inf= parseFunctionDecl();
-				mk(EFunction(inf.args, inf.body, name, inf.ret, __nextPub, __nextStatic), p1, pmax(inf.body));
+				final inf = parseFunctionDecl();
+
+				if (__nextStatic || __nextPub) {
+					final __exprDef = EMeta("rs_accessModifier", [
+						Tools.makeBoolExpr(false),
+						Tools.makeBoolExpr(__nextPub),
+						Tools.makeBoolExpr(__nextStatic)
+					], mk(EFunction(inf.args, inf.body, name, inf.ret)));
+
+					{
+						e: __exprDef.toExpr().e,
+						pmin: p1,
+						pmax: pmax(inf.body),
+						origin: "rulescript",
+						line: 0
+					};
+				} else {
+					mk(EFunction(inf.args, inf.body, name, inf.ret), p1, pmax(inf.body));
+				}
 			case 'untyped':
 				mk(EUntyped(parseExpr()));
 			case 'cast':

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -120,7 +120,7 @@ class HxParser extends Parser
 		if (parameters.allowTypePath != null)
 			parser.allowTypePath = parameters.allowTypePath;
 
-		if(parameters.allowSharedVariables != null)
+		if (parameters.allowSharedVariables != null)
 			parser.allowSharedVariables = parameters.allowSharedVariables;
 	}
 
@@ -179,8 +179,6 @@ class HScriptParser extends hscript.Parser
 	static inline final tokenMax:Int = 0;
 	#end
 
-	private var __nextShared:Bool = false;
-	
 	public function new()
 	{
 		super();
@@ -783,36 +781,25 @@ class HScriptParser extends hscript.Parser
 					e = parseExpr();
 				else
 					push(tk);
-				var expr = (props == null) ? EVar(ident, t, e, false, id == "final") : EProp(ident, props.get, props.set, t, e, null);
-				if (__nextShared) {
-					mk(EMeta(":contextValue", [
-						Tools.makeBoolExpr(__nextShared)
-					], expr.toExpr()), p1, e == null ? tokenMax : pmax(e));
-				} else {
-					mk(expr, p1, e == null ? tokenMax : pmax(e));
-				}
-		
+
+				final expr = if (props == null)
+					EVar(ident, t, e, false, id == 'final')
+				else
+					EProp(ident, props.get, props.set, t, e);
+
+				mk(expr, p1, (e == null) ? tokenMax : pmax(e));
+
 			case "function":
 				var name:String = null;
 				final tk = token();
-				switch tk { case TId(id): name = id; default: push(tk); }
+				switch tk
+				{
+					case TId(id): name = id;
+					default: push(tk);
+				}
 				final inf = parseFunctionDecl();
 
-				if (__nextShared) {
-					final __exprDef = EMeta(":contextValue", [
-						Tools.makeBoolExpr(__nextShared)
-					], mk(EFunction(inf.args, inf.body, name, inf.ret)));
-
-					{
-						e: __exprDef.toExpr().e,
-						pmin: p1,
-						pmax: pmax(inf.body),
-						origin: "rulescript",
-						line: 0
-					};
-				} else {
-					mk(EFunction(inf.args, inf.body, name, inf.ret), p1, pmax(inf.body));
-				}
+				mk(EFunction(inf.args, inf.body, name, inf.ret), p1, pmax(inf.body));
 			case 'untyped':
 				mk(EUntyped(parseExpr()));
 			case 'cast':
@@ -880,26 +867,17 @@ class HScriptParser extends hscript.Parser
 
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
-			case "static", "public"  if (mode == DEFAULT && allowSharedVariables):
-				// i'm lazy okay, leave me alone :sob:
-				// there is defiantly a easier and better way to do this, butttt, ehh -orbl
-				var result:Expr;
-				final __isShared:Bool = (id == "static" || id == "public");
-				if (__isShared) __nextShared = true;
-				final __nextToken:Token = token();
-				switch __nextToken {
-					case TId("function"), TId("public"), TId("static"), TId("final"), TId("override"), TId("var"):
-						result = parseStructure(switch __nextToken {
-							case TId(n): n;
-							default: "";
-						});
-					default:
-						unexpected(__nextToken);
-						result = null;
-				}
 
-				if (__isShared) __nextShared = false;
-				result;
+			case "static", "public" if (mode == DEFAULT && allowSharedVariables):
+				final e:Expr = parseExpr();
+
+				switch (e.getExpr())
+				{
+					case EVar(n, _), EProp(n, _), EFunction(_, _, n) if (n != null):
+						mk(EMeta(':contextValue', null, e), p1, tokenMax);
+					default:
+						unexpected(TId(id));
+				}
 			default:
 				super.parseStructure(id);
 		}

--- a/rulescript/parsers/HxParser.hx
+++ b/rulescript/parsers/HxParser.hx
@@ -17,7 +17,8 @@ typedef HxParserParams =
 	var ?allowUsing:Bool;
 	var ?allowStringInterpolation:Bool;
 	var ?allowTypePath:Bool;
-	var ?allowSharedVariables:Bool;
+	var ?allowStaticVariables:Bool;
+	var ?allowPublicVariables:Bool;
 }
 
 enum HxParserMode
@@ -79,7 +80,8 @@ class HxParser extends Parser
 			allowImport: true,
 			allowUsing: true,
 			allowStringInterpolation: true,
-			allowSharedVariables: true,
+			allowPublicVariables: true,
+			allowStaticVariables: true,
 			allowTypePath: true
 		});
 	}
@@ -120,8 +122,11 @@ class HxParser extends Parser
 		if (parameters.allowTypePath != null)
 			parser.allowTypePath = parameters.allowTypePath;
 
-		if (parameters.allowSharedVariables != null)
-			parser.allowSharedVariables = parameters.allowSharedVariables;
+		if(parameters.allowStaticVariables != null)
+			parser.allowStaticVariables = parameters.allowStaticVariables;
+
+		if(parameters.allowPublicVariables != null)
+			parser.allowPublicVariables = parameters.allowPublicVariables;
 	}
 
 	override public function parse(code:String):Expr
@@ -164,7 +169,8 @@ class HScriptParser extends hscript.Parser
 {
 	public var mode:HxParserMode;
 
-	public var allowSharedVariables:Bool = true;
+	public var allowPublicVariables:Bool = true;
+	public var allowStaticVariables:Bool = true;
 
 	public var allowPackage:Bool = true;
 	public var allowImport:Bool = true;
@@ -868,18 +874,24 @@ class HScriptParser extends hscript.Parser
 				var args = parseExprList(TPClose);
 				mk(ENew(a.join("."), args, typeParams), p1);
 
-			case "static", "public" if (mode == DEFAULT && allowSharedVariables):
-				final e:Expr = parseExpr();
+			case "public" if (mode == DEFAULT && allowPublicVariables):
+				parseContext(id, p1, false, true);
 
-				switch (e.getExpr())
-				{
-					case EVar(n, _), EProp(n, _), EFunction(_, _, n) if (n != null):
-						mk(EMeta(':contextValue', null, e), p1, tokenMax);
-					default:
-						unexpected(TId(id));
-				}
+			case "static" if (mode == DEFAULT && allowStaticVariables):
+				parseContext(id, p1, true, false);
 			default:
 				super.parseStructure(id);
+		}
+	}
+
+	// my brain 🥴
+	function parseContext(id, p1, isStatic:Bool, isPublic:Bool) {
+		final e:Expr = parseExpr();
+		switch (e.getExpr()) {
+			case EVar(n, _), EProp(n, _), EFunction(_, _, n) if (n != null):
+				return mk(EMeta(':contextValue', [Tools.makeBoolExpr(isPublic), Tools.makeBoolExpr(isStatic)], e), p1, tokenMax);
+			default:
+				return unexpected(TId(id));
 		}
 	}
 


### PR DESCRIPTION
This pull request adds support for **public**/**static variables** that can be used across different interps via an instance of the `Context` class.

> [!WARNING]
> This feature is only implemented **in `RuleScriptInterp`**. ~~Support for `NeoInterp` and `BytecodeInterp` **MIGHT** be added in the future.~~

---
### How to apply (???)

```haxe
@:contextValue('static') // static
@:contextValue('public') // public
```
```haxe
// MANUAL
@:contextValue('public') // public
var __public:Bool = false; // does the same thing as a public var

@:contextValue('static') // static
var __static:Bool = false; // does the same thing as a static var

// non weird way
public var __public:Bool = false; // public, duh.
static var __static:Bool = false; // static, duh.
```

---

### How to use.

1. Create a **static instance** of the `Context` class.

   > ```haxe
   >public static var staticContext:Context = new Context();
   >```
2. Assign that instance to `interp.access.context`:

   > ```haxe
   >interp.access.context = staticContext;
   >```

---

You can access the shared (public/static) variable maps directly from the `Context` class instance:

```haxe
// PUBLIC VARIABLES
staticContext.publicVariables;

// STATIC VARIABLES
staticContext.staticVariables;
```

---

ummmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmmm, idk -orbl


> [!TIP]
> TODO:
> - BytecodeInterp
> - NeoInterp
