### PR TITLE
Add resetInterp to the access to allow resetting the interp

### DIFF
--- a/rulescript/RuleScriptAccess.hx
+++ b/rulescript/RuleScriptAccess.hx
@@ -25,9 +25,9 @@ class RuleScriptAccess
 	}
 
 	/**
-	* Resets the interpreters variables.
+	* Resets the interp.
 	*/
-	public function resetVariables():Void
+	public function resetInterp():Void
 	{
 		
 	}

--- a/rulescript/RuleScriptAccess.hx
+++ b/rulescript/RuleScriptAccess.hx
@@ -25,6 +25,14 @@ class RuleScriptAccess
 	}
 
 	/**
+	* Resets the interpreters variables.
+	*/
+	public function resetVariables():Void
+	{
+		
+	}
+
+	/**
 	 * Returns `true` if variable with identifier `name` exists.
 	 * 
 	 * if `name` is null, the result is unspecified.

--- a/rulescript/interps/BytecodeInterp.hx
+++ b/rulescript/interps/BytecodeInterp.hx
@@ -1767,6 +1767,11 @@ class InterpAccess extends RuleScriptAccess
 		return interp.variables = newVariables;
 	}
 
+	override function resetVariables():Void
+	{
+		interp.reset();
+	}
+
 	override function variableExists(name:String):Bool
 	{
 		return interp.variables.exists(name);

--- a/rulescript/interps/BytecodeInterp.hx
+++ b/rulescript/interps/BytecodeInterp.hx
@@ -1767,7 +1767,7 @@ class InterpAccess extends RuleScriptAccess
 		return interp.variables = newVariables;
 	}
 
-	override function resetVariables():Void
+	override function resetInterp():Void
 	{
 		interp.reset();
 	}

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -894,7 +894,7 @@ class RuleScriptInterpAccess extends RuleScriptAccess
 		return interp.variables = newVariables;
 	}
 	
-	override function resetVariables():Void
+	override function resetInterp():Void
 	{
 		interp.resetVariables();
 	}

--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -893,6 +893,11 @@ class RuleScriptInterpAccess extends RuleScriptAccess
 	{
 		return interp.variables = newVariables;
 	}
+	
+	override function resetVariables():Void
+	{
+		interp.resetVariables();
+	}
 
 	override function variableExists(name:String):Bool
 	{

--- a/rulescript/interps/neo/NeoCompiler.hx
+++ b/rulescript/interps/neo/NeoCompiler.hx
@@ -477,7 +477,7 @@ class NeoInterpAccess extends RuleScriptAccess
 		return interp.variables = newVariables;
 	}
 
-	override function resetVariables():Void
+	override function resetInterp():Void
 	{
 		interp.reset();
 	}

--- a/rulescript/interps/neo/NeoCompiler.hx
+++ b/rulescript/interps/neo/NeoCompiler.hx
@@ -477,6 +477,11 @@ class NeoInterpAccess extends RuleScriptAccess
 		return interp.variables = newVariables;
 	}
 
+	override function resetVariables():Void
+	{
+		interp.reset();
+	}
+
 	override function variableExists(name:String):Bool
 	{
 		return interp.variables.exists(name);


### PR DESCRIPTION
I realized you can't directly reset interp via _access_, and that's something that would come in handy on reloading scripts.

Any feedback would be nice!