### PR TITLE
Fix for html5

### DIFF
--- a/rulescript/interps/RuleScriptInterp.hx
+++ b/rulescript/interps/RuleScriptInterp.hx
@@ -798,8 +798,8 @@ class RuleScriptInterp extends hscript.Interp implements IInterp
 
 				{
 					obj: en,
-					hasEnumConstructor: enConstructs.contains,
-					enumHasParams: e -> !simpleEnums.contains(e),
+					hasEnumConstructor: function(v) return enConstructs.contains(v),
+					enumHasParams: function(e) return !simpleEnums.contains(e),
 					getEnumConstructor: function(f:String):Dynamic
 					{
 						return if (simpleEnums.contains(f))


### PR DESCRIPTION
Заметил, что при компиляции на html5 компилятор выдаёт ошибку `Can't create closure on an extern inline member method`. Этот PR фиксит данную ошибку